### PR TITLE
EmailUtility->send(): Create email attachments on the fly

### DIFF
--- a/Classes/Utility/EmailUtility.php
+++ b/Classes/Utility/EmailUtility.php
@@ -89,7 +89,7 @@ class EmailUtility
      * @param array $attachments         Array with attachments. Each item can either be a string or an array.
      *                                   If string, it contains the absolute paths to an existing file on the server.
      *                                   If array, the attached file will be created on-the-fly. The array must be
-     *                                   formed like this: ['body' => 'This is the content of the attachment!', 'name' => 'my_attachment.txt', 'content-type' => 'text/plain']
+     *                                   formed like this: ['body' => 'This is the content of the attachment!', 'name' => 'my_attachment.txt', 'contentType' => 'text/plain']
      *
      * @return int Number of successfully sent emails
      * @throws RuntimeException If the email would be empty

--- a/Classes/Utility/EmailUtility.php
+++ b/Classes/Utility/EmailUtility.php
@@ -86,7 +86,10 @@ class EmailUtility
      * @param array $cc                  CC repipients
      * @param array $bcc                 BCC recipients
      * @param array|string|null $replyTo Reply-To recipient
-     * @param array $attachments         Array with absolute paths for attachments
+     * @param array $attachments         Array with attachments. Each item can either be a string or an array.
+     *                                   If string, it contains the absolute paths to an existing file on the server.
+     *                                   If array, the attached file will be created on-the-fly. The array must be
+     *                                   formed like this: ['body' => 'This is the content of the attachment!', 'name' => 'my_attachment.txt', 'content-type' => 'text/plain']
      *
      * @return int Number of successfully sent emails
      * @throws RuntimeException If the email would be empty
@@ -146,11 +149,16 @@ class EmailUtility
 
         // Add attachments
         foreach($attachments as $key => $attachment) {
-            // If $key is a string, set it as the attachments file name
-            if(is_string($key)) {
-                $mail->attachFromPath($attachment, $key);
+
+            // Determine the filename
+            $filename = is_string($key) ? $key : null;
+
+            // If $attachment is an array, we create the attached file on-the-fly,
+            // otherwise, we assume it's a string and the absolute path to a physical file on the server
+            if(is_array($attachment)) {
+                $mail->attach($attachment['body'], $attachment['name'], $attachment['contentType']);
             } else {
-                $mail->attachFromPath($attachment);
+                $mail->attachFromPath($attachment, $filename);
             }
         }
 


### PR DESCRIPTION
When sending emails with `EmailUtility->send()`, it's now possible to create email attachments on-the-fly, without the need for existing, physical files on the server. Each item of the `$attachments` argument can be either a string or an array now. 

If string, it's the absolute path of an existing file on the server. This is the already existing behaviour. Alternatively , each item now can be an array like this.

```PHP
[
     'body' => 'This is the content of the attachment!',
     'name' => 'my_attachment.txt',
     'contentType' => 'text/plain',
]
```

So this new behaviour **is not** a breaking change and now it's possible to mix attachments of existing and on-the-fly files:

```PHP
$attachments = [
     '/path/to/existing-file.txt',
     '/path/to/another-existing-file.txt',
     [
         'body' => 'This is the content of the attachment!',
         'name' => 'my_attachment.txt',
         'contentType' => 'text/plain',
     ]
];
```

