### PR TITLE
DebugViewHelper

### DIFF
--- a/Classes/ViewHelpers/DebugViewHelper.php
+++ b/Classes/ViewHelpers/DebugViewHelper.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * tollwerk
+ *
+ * @category   Tollwerk
+ * @package    Tollwerk\TwBase
+ * @subpackage Tollwerk\TwBase\ViewHelpers
+ * @author     Joschi Kuphal <joschi@tollwerk.de> / @jkphl
+ * @copyright  Copyright © 2019 Joschi Kuphal <joschi@tollwerk.de> / @jkphl
+ * @license    http://opensource.org/licenses/MIT The MIT License (MIT)
+ */
+
+/***********************************************************************************
+ *  The MIT License (MIT)
+ *
+ *  Copyright © 2019 Joschi Kuphal <joschi@tollwerk.de>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  this software and associated documentation files (the "Software"), to deal in
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *  the Software, and to permit persons to whom the Software is furnished to do so,
+ *  subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ *  FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ *  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ *  IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ***********************************************************************************/
+
+namespace Tollwerk\TwBase\ViewHelpers;
+
+use Closure;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * This DebugViewHelper behaves the same as the regular \TYPO3\CMS\Fluid\ViewHelpers\DebugViewHelper,
+ * but only shows debug output if the users IP address was successfully checked against the current
+ * devIPmask settings.
+ *
+ * @package    Tollwerk\TwBase
+ * @subpackage Tollwerk\TwBase\ViewHelpers
+ */
+class DebugViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\DebugViewHelper
+{
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     *
+     * @return string
+     */
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        // Check if user IP against devIPmask settings, return empty string if not found and devIPmask has no wildcard.
+        if(!GeneralUtility::cmpIP($_SERVER['REMOTE_ADDR'], $GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask'])) {
+            return '';
+        }
+
+        // Return regular debug output
+        return parent::renderStatic($arguments, $renderChildrenClosure, $renderingContext);
+    }
+}

--- a/Docs/ViewHelpers/debug.md
+++ b/Docs/ViewHelpers/debug.md
@@ -1,0 +1,13 @@
+# TYPO3 extension: tw_base
+
+> Collection of building blocks and viewhelpers for TYPO3 projects by tollwerk
+
+## `debug` viewhelper
+
+The `<base:debug>`-ViewHelper works exactly like `<f:debug>`, but checks the user's IP address
+against `$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']` first. If the user's IP address is not found there and
+does not contain wildcards, there will be no debugging output. With this, you can debug fluid templates inside live 
+environments without regular users noticing it.
+
+
+

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ These services don't work out of the box and require particular software to be a
 ## Viewhelpers
 
 * [`cta` viewhelper](Docs/ViewHelpers/cta.md) for rendering CallToAction `<a>` or `<button>` tags
+* [`debug` viewhelper](Docs/ViewHelpers/debug.md) for better debugging of live environments 
 * [`heading` viewhelper](Docs/ViewHelpers/heading.md) for semantic document structuring
 * [`render` viewhelper](Docs/ViewHelpers/render.md) for rendering partials & sections with heading context awareness
 * [`image` viewhelper](Docs/ViewHelpers/image.md) for rendering compressed images


### PR DESCRIPTION
There is a new `<base:debug>`-ViewHelper now. It behaves exactly the same as the native `<f:debug>`-ViewHelper, but checks the user's IP address against `$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']` first. With this you can debug data inside Fluid Templates without disturbing live operations.